### PR TITLE
Add Stojanovski and Fraser (2018) to Table SM2

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -2474,3 +2474,15 @@
     booktitle = {Proceedings of the 22nd Conference on Computational Natural Language Learning},
     year = {2018},
 }
+
+@InProceedings{stojanovski-fraser:2018:WMT,
+  author    = {Stojanovski, Dario  and  Fraser, Alexander},
+  title     = {Coreference and Coherence in Neural Machine Translation: A Study Using Oracle Experiments},
+  booktitle = {Proceedings of the Third Conference on Machine Translation, Volume 1: Research Papers},
+  month     = {October},
+  year      = {2018},
+  address   = {Brussels, Belgium},
+  publisher = {Association for Computational Linguistics},
+  pages     = {49--60},
+  url       = {http://www.aclweb.org/anthology/W18-6306}
+}

--- a/table2.html
+++ b/table2.html
@@ -135,6 +135,15 @@
           <td></td>
         </tr>
         <tr>
+          <td><div class="bibtex_display" bibtexkeys="stojanovski-fraser:2018:WMT"></td>
+          <td>MT</td>
+          <td>Discourse</td>
+          <td>English&#8594;German</td>
+          <td>4627</td>
+          <td>Automatic</td>
+          <td>Test sets created using oracles, an alternative to challenge sets. The method can be applied to different language pairs and datasets.</td>
+        </tr>
+        <tr>
           <td><div class="bibtex_display" bibtexkeys="linzen2016assessing"></td>
           <td>LM</td>
           <td>Subject-verb agreement</td>


### PR DESCRIPTION
"Coreference and Coherence in Neural Machine Translation: A Study Using Oracle Experiments" by Stojanovski and Fraser (WMT 2018) describes a way of evaluating discourse in MT using oracles. It can be added to Table SM2.  